### PR TITLE
Uploads downloads temp dir gc

### DIFF
--- a/sciris/datastore.py
+++ b/sciris/datastore.py
@@ -1,7 +1,7 @@
 """
 datastore.py -- code related to Sciris persistence (both files and database)
     
-Last update: 3/27/18 (gchadder3)
+Last update: 3/28/18 (gchadder3)
 """
 
 """
@@ -45,15 +45,8 @@ from contextlib import closing
 # The path of the Sciris repo.
 scirisRootPath = None
 
-
-
-# The directory that uploaded files are written to as a "way-station."
-uploadsPath = None
-
-# The root path where files may end up being saved.
-fileSaveRootPath = None
-
-
+# Directory (FileSaveDirectory object) for saved files.
+fileSaveDir = None
 
 # Directory (FileSaveDirectory object) for file uploads to be routed to.
 uploadsDir = None
@@ -453,18 +446,64 @@ class DataStore(object):
 # NOTE: If enough code ends up here, we may want to break it out into another 
 # file.
     
-# Wraps a directory where files may get saved by the site.
 class FileSaveDirectory(object):
-    def __init__(self, dirPath=None):
+    """
+    An object wrapping a directory where files may get saved by the web 
+    application.
+    
+    Methods:
+        __init__(dirPath: str [None], tempDir: bool [False]): void -- 
+            constructor
+        cleanup(): void -- clean up after web app is exited
+        clear(): void -- erase the contents of the directory
+        delete(): void -- delete the entire directory
+                    
+    Attributes:
+        dirPath (str) -- the full path of the directory on disk
+        isTempDir (bool) -- is the directory to be spawned on startup and 
+            erased on exit?
+        
+    Usage:
+        >>> newDir = FileSaveDirectory(transferDirPath, tempDir=True)
+    """
+    
+    def __init__(self, dirPath=None, tempDir=False):
+        # Set whether we are a temp directory.
+        self.isTempDir = tempDir
+               
+        # If no path is specified, create the temp directory.
         if dirPath is None:
             self.dirPath = mkdtemp()
+            
+        # Otherwise...
         else:
+            # Set the path to what was passed in.
             self.dirPath = dirPath
+            
+            # If the directory doesn't exist yet, create it.
+            if not os.path.exists(dirPath):            
+                os.mkdir(dirPath)
+            
+        # Register the cleanup method to be called on web app exit.
         atexit.register(self.cleanup)
             
     def cleanup(self):
-        print 'Cleaning up FileSaveDirectory at %s' % self.dirPath
+        # If we are a temp directory, do the cleanup.
+        if self.isTempDir:
+            # Show cleanup message.
+            print '>> Cleaning up FileSaveDirectory at %s' % self.dirPath
+            
+            # Delete the entire directory (file contents included).
+            self.delete()
+            
+    def clear(self):
+        # Delete the entire directory (file contents included).
+        rmtree(self.dirPath)
         
+        # Create a fresh direcgtory
+        os.mkdir(self.dirPath)
+    
+    def delete(self):
         # Delete the entire directory (file contents included).
         rmtree(self.dirPath)
         

--- a/sciris/project.py
+++ b/sciris/project.py
@@ -1,7 +1,7 @@
 """
 project.py -- code related to Sciris project management
     
-Last update: 3/20/18 (gchadder3)
+Last update: 3/27/18 (gchadder3)
 """
 
 #
@@ -568,9 +568,9 @@ def download_project(project_id):
     # Load the project with the matching UID.
     theProj = load_project(project_id, raise_exception=True)
     
-    # Use the uploads directory to put the file in.
-    dirname = ds.uploadsPath
-    
+    # Use the downloads directory to put the file in.
+    dirname = ds.downloadsDir.dirPath
+        
     # Create a filename containing the project name followed by a .prj 
     # suffix.
     fileName = '%s.prj' % theProj.name
@@ -598,8 +598,8 @@ def load_zip_of_prj_files(project_ids):
     if request.endpoint != 'downloadProjectRPC':
         return {'error': 'Unauthorized RPC'}   
     
-    # Use the uploads directory to put the file in.
-    dirname = ds.uploadsPath
+    # Use the downloads directory to put the file in.
+    dirname = ds.downloadsDir.dirPath
 
     # Build a list of ProjectSO objects for each of the selected projects, 
     # saving each of them in separate .prj files.


### PR DESCRIPTION
I'm implemented changes in `datastore.py` and `project.py` to change the way uploading and downloading directories work.  These now use the `FileSaveDirectory` class defined in `datastore.py`.   This is capable of creating and temporary directories (which get erased, along with their contents when the web app is halted).  Note: To test this, you need the corresponding changes in the `hptool` repo.